### PR TITLE
fix: 修复快捷键逗号进入1s的功能外泄到非code page 页面也能触发

### DIFF
--- a/src/contents/event/index.ts
+++ b/src/contents/event/index.ts
@@ -1,5 +1,7 @@
+import { isHasReadmeDom } from '../utils/is';
+
 function toGithub1s () {
-  if (!window) {
+  if (!window || !isHasReadmeDom()) {
     return;
   }
 

--- a/src/contents/utils/is.ts
+++ b/src/contents/utils/is.ts
@@ -1,0 +1,9 @@
+export const isHasReadmeDom = () => {
+  if (!document) {
+    return false;
+  }
+  
+  const readmeInstance = document.getElementById('readme');
+
+  return Boolean(readmeInstance)
+}


### PR DESCRIPTION
解决例如在编写 issues 或者其他涉及到键盘输入的场景按逗号会误触快捷键1s的问题