### PR TITLE
flx: 修改翻译识别对段落分割标签识别增强，添加git忽略配置，添加 editorconfig 配置

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.{js,mjs,cjs,jsx,ts,tsx}]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,7 @@ keys.json
 .tsbuildinfo
 
 # ========
-assets/google
+assets/google、
+
+# idea
+.idea

--- a/__test__.html
+++ b/__test__.html
@@ -1,91 +1,115 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<head>
+    <meta charset="UTF-8"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Document</title>
-  </head>
+</head>
 
-  <body>
+<body>
+<div>
+    <h1>Test content</h1>
+    <p>
+        our answer could be improved with additional supporting information.
+        Please edit to add further details, such as citations or documentation,
+        so that others can confirm that your answer is correct. You can find
+        more information on how to write good answers in the help center. –
+        Community Bot
+    </p>
+
     <div>
-      <h1>Test content</h1>
-      <h2>Please use dev-go to translate this page</h2>
+        This is a piece of test text, which will include some tags, such as
+        <a href="https://www.google.com">link</a>、
+        <strong>strong</strong>、
+        <em>em</em>、
+        <del>del</del>
+        、
+        <ins>ins</ins>
+        、
+        <sub>sub</sub>、
+        <sup>sup</sup>、
+        <mark>mark</mark>
+        、
+        <small>small</small>、
+        <big>big</big>、
+        <u>u</u>、
+        <s>s</s>、
+        <q>q</q>、
+        <cite>cite</cite>、
+        <abbr>abbr</abbr>、
+        <dfn>dfn</dfn>、
+        <time>time</time>
+        、
+        <var>var</var>、
+        <samp>samp</samp>、
+        <kbd>kbd</kbd>、
+        <i>i</i>、
+        <b>b</b>、
+        <span>span</span>
+        The expectation is that these tags will not be understood as a node alone, but together with the parent node.
 
-      <div>
-        <h3>Test paragraph</h3>
-        <p>
-          our answer could be improved with additional supporting information. Please edit to add
-          further details, such as citations or documentation, so that others can confirm that your
-          answer is correct. You can find more information on how to write good answers in the help
-          center. – Community Bot
-        </p>
-      </div>
+        <br>
+
+        But for block-level elements, it will be understood as a separate node, such as
+        <div>this is a <b>div</b> element</div>
+        <p>this is a <b>p</b> element</p>
+        <h1>this is a h1 element</h1>
+        <ul>
+            <li>this is a li element</li>
+        </ul>
+        <dl>
+            <dt>this is a dt element</dt>
+            <dd>this is a dd element</dd>
+        </dl>
+
+        <br>
+
+        There are also some special tags, such as <b>br</b>, <b>hr</b> should also be understood as a sign of the end of
+        a paragraph.
+        here is a br tag: <br>
+        here is a hr tag:
+        <hr>
+        They will both be understood as the end of a paragraph.
     </div>
 
     <div>
-      <h3>Test list and link</h3>
-      <ul>
-        <li>
-          You can find more information on
-          <a href="">test link</a>
-          how to write good answers in the help center
-        </li>
-        <li>
-          You can find more information on
-          <a href="">test link</a>
-          how to write good answers in the help center
-        </li>
-      </ul>
+        <ul>
+            <li>
+                <a href="">
+                    our answer could be improved with additional supporting information.
+                </a>
+            </li>
+
+            <li>
+                <a href="">
+                    our answer could be improved with additional supporting information.
+                </a>
+            </li>
+            <li>
+                <a href="">
+                    our answer could be improved with additional supporting information.
+                </a>
+            </li>
+            <li>
+                <a href="">
+                    our answer could be improved with additional supporting information.
+                </a>
+            </li>
+        </ul>
     </div>
-
-    <div>
-      <h3>Test code</h3>
-      <pre>
-        <code>
-          const test = 'test';
-          console.log(test);
-        </code>
-        <code>
-          const a = 123; 
-          function test (){
-            let b=333;
-          }
-        </code>
-      </pre>
-    </div>
-
-
-    <div>
-      <h3>Test table</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Test</th>
-            <th>Test</th>
-            <th>Test</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Test</td>
-            <td>Test</td>
-            <td>Test</td>
-          </tr>
-        </tbody>
-    </div>
-
-  </body>
+    <!-- <script type="text/javascript">
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          { pageLanguage: 'en' },
+          'google_translate_element',
+        )
+      }
+    </script>
+    <script
+      type="text/javascript"
+      src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+    ></script> -->
+</div>
+</body>
 </html>
-<!-- <script type="text/javascript">
-    function googleTranslateElementInit() {
-      new google.translate.TranslateElement(
-        { pageLanguage: 'en' },
-        'google_translate_element',
-      )
-    }
-  </script>
-  <script
-    type="text/javascript"
-    src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
-  ></script> -->

--- a/src/contents/translate.ts
+++ b/src/contents/translate.ts
@@ -82,34 +82,22 @@ function loopTransNode(element) {
 
   // 遍历所有的子节点,  需要翻译的元素
   childrenList.forEach((tag) => {
-    // 如果是文本节点，且不为空时，发送翻译请求
-    if (tag?.nodeType === 3 && tag.textContent.trim() !== '') {
-      // 如果文本中全是中文或空，不翻译
-      if (!tag.textContent || /^[\u4e00-\u9fa5]+$/.test(tag.textContent)) return
-      // 发送翻译请求
-      chrome.runtime.sendMessage({ text: tag.textContent, type: 'translate' }, (res) => {
-        insertTransResult(tag, res.text)
-      })
-    } else {
-      tag && loopTransNode(tag)
-    }
+    if (hasTransTextNode(tag)) {
+      // 不需要翻译的元素
+      if (!hasTranslate(tag.textContent)) return;
 
-    // if (hasTransTextNode(tag)) {
-    //   // 不需要翻译的元素
-    //   if (!hasTranslate(tag.textContent)) return;
-    //
-    //   // 拼接需要翻译的文本
-    //   translateText += tag.textContent
-    //   lastElement = tag
-    // } else {
-    //   // 进入到这里证明一个段落已经结束，开始翻译
-    //   sentenceTrans(translateText, lastElement)
-    //   translateText = ''
-    //   lastElement = null
-    //
-    //   // 递归处理非内联元素或者文本节点
-    //   loopTransNode(tag)
-    // }
+      // 拼接需要翻译的文本
+      translateText += tag.textContent
+      lastElement = tag
+    } else {
+      // 进入到这里证明一个段落已经结束，开始翻译
+      sentenceTrans(translateText, lastElement)
+      translateText = ''
+      lastElement = null
+
+      // 递归处理非内联元素或者文本节点
+      loopTransNode(tag)
+    }
   })
 
   // 最后一个段落的翻译


### PR DESCRIPTION
修改段落分割标签识别，针对段落中的行内元素过滤，一个段落内不再出现多个翻译结果，针对换行元素进行识别，换行元素自成一个段落
![image](https://user-images.githubusercontent.com/32668264/205480779-40b186f1-cf86-41bc-997d-9e6053e0199c.png)
