### PR TITLE
fix: 修复对段落标签解析方式，针对内联元素翻译解析合并到父级 #5

### DIFF
--- a/__test__.html
+++ b/__test__.html
@@ -10,82 +10,127 @@
   <body>
     <div>
       <h1>Test content</h1>
-      <h2>Please use dev-go to translate this page</h2>
+      <p>
+        our answer could be improved with additional supporting information. Please edit to add
+        further details, such as citations or documentation, so that others can confirm that your
+        answer is correct. You can find more information on how to write good answers in the help
+        center. – Community Bot
+      </p>
 
       <div>
-        <h3>Test paragraph</h3>
+        This is a piece of test text, which will include some tags, such as
+        <a href="https://www.google.com">link</a>
+        、
+        <strong>strong</strong>
+        、
+        <em>em</em>
+        、
+        <del>del</del>
+        、
+        <ins>ins</ins>
+        、
+        <sub>sub</sub>
+        、
+        <sup>sup</sup>
+        、
+        <mark>mark</mark>
+        、
+        <small>small</small>
+        、
+        <big>big</big>
+        、
+        <u>u</u>
+        、
+        <s>s</s>
+        、
+        <q>q</q>
+        、
+        <cite>cite</cite>
+        、
+        <abbr>abbr</abbr>
+        、
+        <dfn>dfn</dfn>
+        、
+        <time>time</time>
+        、
+        <var>var</var>
+        、
+        <samp>samp</samp>
+        、
+        <kbd>kbd</kbd>
+        、
+        <i>i</i>
+        、
+        <b>b</b>
+        、
+        <span>span</span>
+        The expectation is that these tags will not be understood as a node alone, but together with
+        the parent node.
+
+        <br />
+
+        But for block-level elements, it will be understood as a separate node, such as
+        <div>
+          this is a
+          <b>div</b>
+          element
+        </div>
         <p>
-          our answer could be improved with additional supporting information. Please edit to add
-          further details, such as citations or documentation, so that others can confirm that your
-          answer is correct. You can find more information on how to write good answers in the help
-          center. – Community Bot
+          this is a
+          <b>p</b>
+          element
         </p>
+        <h1>this is a h1 element</h1>
+        <ul>
+          <li>this is a li element</li>
+        </ul>
+        <dl>
+          <dt>this is a dt element</dt>
+          <dd>this is a dd element</dd>
+        </dl>
+
+        <br />
+
+        There are also some special tags, such as
+        <b>br</b>
+        ,
+        <b>hr</b>
+        should also be understood as a sign of the end of a paragraph. here is a br tag:
+        <br />
+        here is a hr tag:
+        <hr />
+        They will both be understood as the end of a paragraph.
       </div>
+
+      <div>
+        <ul>
+          <li>
+            <a href="">our answer could be improved with additional supporting information.</a>
+          </li>
+
+          <li>
+            <a href="">our answer could be improved with additional supporting information.</a>
+          </li>
+          <li>
+            <a href="">our answer could be improved with additional supporting information.</a>
+          </li>
+          <li>
+            <a href="">our answer could be improved with additional supporting information.</a>
+          </li>
+        </ul>
+      </div>
+      <!-- <script type="text/javascript">
+      function googleTranslateElementInit() {
+        new google.translate.TranslateElement(
+          { pageLanguage: 'en' },
+          'google_translate_element',
+        )
+      }
+    </script>
+    <script
+      type="text/javascript"
+      src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
+    ></script> -->
     </div>
-
-    <div>
-      <h3>Test list and link</h3>
-      <ul>
-        <li>
-          You can find more information on
-          <a href="">test link</a>
-          how to write good answers in the help center
-        </li>
-        <li>
-          You can find more information on
-          <a href="">test link</a>
-          how to write good answers in the help center
-        </li>
-      </ul>
-    </div>
-
-    <div>
-      <h3>Test code</h3>
-      <pre>
-        <code>
-          const test = 'test';
-          console.log(test);
-        </code>
-        <code>
-          const a = 123; 
-          function test (){
-            let b=333;
-          }
-        </code>
-      </pre>
-    </div>
-
-
-    <div>
-      <h3>Test table</h3>
-      <table>
-        <thead>
-          <tr>
-            <th>Test</th>
-            <th>Test</th>
-            <th>Test</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Test</td>
-            <td>Test</td>
-            <td>Test</td>
-          </tr>
-        </tbody>
-    </div>
-
   </body>
 </html>
-<!-- <script type="text/javascript">
-    function googleTranslateElementInit() {
-      new google.translate.TranslateElement(
-        { pageLanguage: 'en' },
-        'google_translate_element',
-      )
-    }
-  </script>
-  <script
-    type="text/javascript"
-    src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"
-  ></script> -->


### PR DESCRIPTION
fix: 修复对段落标签解析方式，针对内联元素翻译解析合并到父级 #5

![image](https://user-images.githubusercontent.com/32668264/205485099-538916cd-fbf8-4a29-9a31-02f46c05b256.png)
