### PR TITLE
fix: 解决 1s 编辑器快捷键在非期望的路由页也能进入的问题

### DIFF
--- a/src/contents/event/index.ts
+++ b/src/contents/event/index.ts
@@ -1,5 +1,7 @@
+import { isGithubCodePage } from '../utils/is'
+
 function toGithub1s() {
-  if (!window) {
+  if (!isGithubCodePage()) {
     return
   }
 

--- a/src/contents/hooks/useGitHub.ts
+++ b/src/contents/hooks/useGitHub.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo } from 'react'
 
+import { isGithubCodePage } from '../utils/is'
 import registerKeyDownListen from '../register/keydownListen'
 
 const useGitHub = () => {
@@ -7,17 +8,8 @@ const useGitHub = () => {
     registerKeyDownListen()
   }, [])
 
-  const isCodePage = useMemo<boolean>(() => {
-    const url = window.location.href
-    const fileNavigation = document.querySelectorAll('.file-navigation')
-    const isHasBlob = url.includes('/blob/')
-    const isHasTree = url.includes('/tree/')
-
-    return fileNavigation.length > 0 || isHasBlob || isHasTree
-  }, [])
-
   return {
-    isCodePage,
+    isCodePage: isGithubCodePage(),
   }
 }
 

--- a/src/contents/register/keydownListen.ts
+++ b/src/contents/register/keydownListen.ts
@@ -2,11 +2,15 @@ import { keyCodeEnums } from '../../enum/commandEnum'
 import { toGithub1s } from '../event'
 
 const keyCodeEventMap: Record<string, () => void> = {
-  [keyCodeEnums.comma]: toGithub1s,
+  [keyCodeEnums.Comma]: toGithub1s,
 }
 
 const keyDownListen = () => {
   window.addEventListener('keydown', (e) => {
+    const isHasSetKey = keyCodeEnums.Comma === e.code;
+
+    if (!isHasSetKey) return
+
     keyCodeEventMap[e.code]()
   })
 }

--- a/src/contents/utils/is.ts
+++ b/src/contents/utils/is.ts
@@ -1,0 +1,14 @@
+export const isGithubCodePage = (): boolean => {
+  const url = window.location.href
+  const fileNavigationInstance = document.querySelectorAll('.file-navigation')
+  const isHasReadme = Boolean(document.getElementById('readme'))
+  const isHasBlob = url.includes('/blob/')
+  const isHasTree = url.includes('/tree/')
+  const res = fileNavigationInstance.length > 0 || isHasBlob || isHasTree || isHasReadme
+
+  return res
+}
+
+export const isHasWindow = (): boolean => {
+  return Boolean(window)
+}

--- a/src/enum/commandEnum.ts
+++ b/src/enum/commandEnum.ts
@@ -1,5 +1,5 @@
 //
 export enum keyCodeEnums {
-  /** 逗号的 code  */
-  comma = 'Comma',
+  /** 逗号的 按键  */
+  Comma = 'Comma',
 }


### PR DESCRIPTION
1. 解决 bob 路由的场景不能快捷键进入 1s
2. 解决 tree 路由场景不能快捷键进入 1s
3. 解决其他 非 code page 场景的时候也能进入的问题

(按钮显示问题这个建议留一个 issues，后期再看看有没有什么方案)