### PR TITLE
fix: 移除默认临时邮箱并提高固定栏容量数字对比度

### DIFF
--- a/src/features/newtab/PinnedNav.tsx
+++ b/src/features/newtab/PinnedNav.tsx
@@ -43,7 +43,7 @@ export default function PinnedNav({ items, onUnpin }: PinnedNavProps) {
       <div className='mb-2 flex items-center gap-1.5 px-1 text-xs text-slate-400 dark:text-slate-500'>
         <PinIcon className='h-3 w-3' />
         <span>固定</span>
-        <span className='text-slate-300 dark:text-slate-600'>
+        <span className='text-slate-500 dark:text-slate-600'>
           {items.length}/{PIN_LIMIT}
         </span>
       </div>

--- a/src/features/newtab/engines.ts
+++ b/src/features/newtab/engines.ts
@@ -167,7 +167,6 @@ export const DEFAULT_QUICK_NAV: QuickNavItem[] = [
   { id: 'eleduck', title: '电鸭社区', url: 'https://eleduck.com', category: 'community' },
   // 工具
   { id: 'figma', title: 'Figma', url: 'https://www.figma.com', category: 'tools' },
-  { id: '24mail', title: '临时邮箱', url: 'https://24mail.chacuo.net', category: 'tools' },
   { id: 'excalidraw', title: 'Excalidraw', url: 'https://excalidraw.com', category: 'tools' },
   { id: 'codepen', title: 'CodePen', url: 'https://codepen.io', category: 'tools' },
   { id: 'tinypng', title: 'TinyPNG', url: 'https://tinypng.com', category: 'tools' },


### PR DESCRIPTION
## Summary
- 从默认快捷导航种子中移除「临时邮箱」（`24mail`）；已落库用户不受影响，可自行删除
- 白天模式下固定栏容量数字（`n/16`）由 `slate-300` 调整为 `slate-500`，避免与浅色背景对比度过低；深色模式保持不变

## Test plan
- [x] 新安装 / 清空导航后，工具分类中不再出现「临时邮箱」
- [x] 已有「临时邮箱」的用户刷新后该项仍在，可手动删除
- [x] 白天模式：固定栏标题旁 `当前数/上限` 清晰可读
- [ ] 深色模式：容量数字观感与改前一致


Made with [hottaiger](https://github.com/hottaiger)