### PR TITLE
feat: popup 关闭后重新打开时恢复上次选中的功能页

### DIFF
--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -11,6 +11,7 @@ import Tabs from '@/ui/Tabs'
 import {
   defaultPopupTab,
   isPopupShortcutTab,
+  popupLastActiveTab,
   popupInitialTab,
   type PopupShortcutTab,
 } from '@/utils/settings'
@@ -37,42 +38,50 @@ export default function App() {
     activeRef.current = active
   }, [active])
 
-  const applyShortcutTab = useCallback((tab: PopupShortcutTab) => {
-    popupInitialTab.setValue('')
-
-    if (activeRef.current === tab) {
-      window.close()
-      return
-    }
-
+  const selectTab = useCallback((tab: PopupShortcutTab) => {
     activeRef.current = tab
     setActive(tab)
+    void popupLastActiveTab.setValue(tab)
   }, [])
 
-  // 打开面板时定位 Tab：优先一次性信号（Alt+1..4 等命令写入），否则用「功能」页配置的默认 Tab。
-  useEffect(() => {
-    Promise.all([popupInitialTab.getValue(), defaultPopupTab.getValue()]).then(
-      ([tab, fallback]) => {
-        const defaultTab = isPopupShortcutTab(fallback) ? fallback : DEFAULT_POPUP_TAB
-        setDefaultShortcutTab(defaultTab)
+  const applyShortcutTab = useCallback(
+    (tab: PopupShortcutTab) => {
+      popupInitialTab.setValue('')
 
-        if (tab && isPopupShortcutTab(tab)) {
-          activeRef.current = tab
-          setActive(tab)
-          popupInitialTab.setValue('')
-          return
-        }
-        if (tab) popupInitialTab.setValue('')
-        activeRef.current = defaultTab
-        setActive(defaultTab)
-      },
-    )
+      if (activeRef.current === tab) {
+        window.close()
+        return
+      }
+
+      selectTab(tab)
+    },
+    [selectTab],
+  )
+
+  // 打开面板时定位 Tab：优先一次性快捷键指令，其次恢复上次选中项，最后使用默认 Tab。
+  useEffect(() => {
+    Promise.all([
+      popupInitialTab.getValue(),
+      popupLastActiveTab.getValue(),
+      defaultPopupTab.getValue(),
+    ]).then(([tab, lastActiveTab, fallback]) => {
+      const defaultTab = isPopupShortcutTab(fallback) ? fallback : DEFAULT_POPUP_TAB
+      setDefaultShortcutTab(defaultTab)
+
+      if (tab && isPopupShortcutTab(tab)) {
+        selectTab(tab)
+        popupInitialTab.setValue('')
+        return
+      }
+      if (tab) popupInitialTab.setValue('')
+      selectTab(isPopupShortcutTab(lastActiveTab) ? lastActiveTab : defaultTab)
+    })
 
     // 读取实际注册的命令快捷键（用户在 chrome://extensions/shortcuts 改动后会同步）
     browser.commands?.getAll().then((cmds) => {
       setShortcuts(Object.fromEntries(cmds.map((c) => [c.name, c.shortcut || ''])))
     })
-  }, [])
+  }, [selectTab])
 
   useEffect(() => {
     const unwatch = defaultPopupTab.watch((tab) => {
@@ -104,6 +113,10 @@ export default function App() {
     active === defaultShortcutTab ? shortcuts[DEFAULT_POPUP_COMMAND] || '' : ''
   const activeShortcut = shortcuts[TAB_COMMANDS[active]] || defaultShortcut
 
+  const handleTabChange = (tab: string) => {
+    if (isPopupShortcutTab(tab)) selectTab(tab)
+  }
+
   return (
     <div className='popup-shell relative flex w-[500px] flex-col overflow-hidden text-slate-800'>
       <span aria-hidden='true' className='popup-ambient popup-ambient-a' />
@@ -117,7 +130,7 @@ export default function App() {
           </span>
           <span className='text-sm font-semibold tracking-tight text-slate-800'>{SHIP_NAME}</span>
         </div>
-        <Tabs value={active} tabs={POPUP_PAGES} onChange={setActive} />
+        <Tabs value={active} tabs={POPUP_PAGES} onChange={handleTabChange} />
       </header>
 
       {/* 内容区 */}

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -292,6 +292,11 @@ export const popupInitialTab = storage.defineItem<PopupShortcutTab | ''>('local:
   fallback: '',
 })
 
+/** popup 面板上次选中的功能页（本机持久化，用于下次从工具栏重新打开时恢复）。 */
+export const popupLastActiveTab = storage.defineItem<PopupShortcutTab>('local:popupLastActiveTab', {
+  fallback: 'translate',
+})
+
 /**
  * 点击工具栏图标或 Alt+1 打开 popup 时默认定位的 Tab（在「功能」页可配置，默认翻译）。
  * 跨设备同步：换设备后默认 Tab 偏好保持一致。


### PR DESCRIPTION
## 摘要

- 将 popup 当前选中的功能页（翻译 / 待办 / 网络 / 资源等）持久化到本机 `local:popupLastActiveTab`
- 通过工具栏重新打开 popup 时，优先恢复上次有效功能页；无有效历史时回退到「功能」页配置的默认 Tab
- 快捷键 / 后台一次性指定打开页仍优先于上次选中页，语义不变
- 该状态仅本机使用，不纳入跨设备备份或同步

## 改动说明

- `src/utils/settings.ts`：新增 `popupLastActiveTab` 存储项
- `src/entrypoints/popup/App.tsx`：切换 Tab 时写入上次活动页；打开时按「一次性信号 → 上次活动页 → 默认页」解析初始 Tab

## 测试计划

- [x] 在 popup 切到「待办」，点击页面空白处关闭，再点工具栏图标，应仍显示「待办」
- [x] 切到其他有效功能页后关闭再打开，应恢复关闭前选中的页
- [x] 用快捷键指定打开某一功能页时，应显示指定页（而非仅恢复历史页）
- [x] 清除 / 无历史记录时，应回退到「功能」页配置的默认 Tab
- [x] `pnpm compile` 与相关 ESLint / Prettier 检查通过


Made with [Cursor](https://cursor.com)